### PR TITLE
[SKLT-2150] [Fingerprint][Rules page]  the End time should be after start time for tardiness rule   

### DIFF
--- a/src/app/main/rules/rule-form/rule-form.component.ts
+++ b/src/app/main/rules/rule-form/rule-form.component.ts
@@ -74,7 +74,7 @@ export class RuleFormComponent implements OnInit {
     } else if (!this.isFormSubmitted && (!tardinessRule.start_time || !tardinessRule.end_time || tardinessRule.start_time == '' || tardinessRule.end_time == '')) {
       return
     } else {
-      tardinessRule.invalidTime = (tardinessRule.start_time > tardinessRule.end_time) ? true : false;
+      tardinessRule.invalidTime = (tardinessRule.start_time >= tardinessRule.end_time) ? true : false;
       this.invalidAllTardinessTime = this.rule.tardiness_rules_attributes!.filter(tardinessRule => (tardinessRule.invalidTime)).length > 0;
     }
 


### PR DESCRIPTION

## :red_circle: Bug 

### :memo: Problem
- the end time equal the start time

### :memo: Solution
- add equal symbol in the validation condition
_______________________________________________
### :link: Ticket link https://trianglz.atlassian.net/browse/SKLT-2150
