### PR TITLE
[SKLT-2149] [Fingerprint][Rules page] if the user don't enter any value in the "leave types" should display this field by red border

### DIFF
--- a/src/app/main/rules/rule-form/rule-form.component.html
+++ b/src/app/main/rules/rule-form/rule-form.component.html
@@ -100,13 +100,13 @@
                   <div class="border-top" *ngIf="tardinessRule.open">
                     <div class="row">
                       <div class="col-md-3">
-                        <div class="form-group mtb-2">
+                        <div class="form-group mtb-2" [class.has-error]="(leaveType.invalid && leaveType.dirty) || (ruleForm.submitted && leaveType.invalid)">
                           <label>{{'tr_leave_types' | translate}}</label>
                           <div class="input-with-icon bg-white width-100">
                             <ng-select class="s-control s-select" bindValue="id" (scrollToEnd)=nextBatch()
-                              bindLabel="name" [loading]="leaveTypesLoading" placeholder="{{'tr_select' | translate}}"
+                              bindLabel="name" [loading]="leaveTypesLoading"  #leaveType="ngModel" placeholder="{{'tr_select' | translate}}"
                               notFoundText="{{'tr_no_items_found' | translate}}" autofocus
-                              [(ngModel)]="tardinessRule.leave_type_id" [items]="leaveTypes" name="tardinessLeaveType_{{index}}">
+                              [(ngModel)]="tardinessRule.leave_type_id" [items]="leaveTypes" name="tardinessLeaveType_{{index}}" required>
                               <ng-template ng-header-tmp>
                                 <div class="pt-2 text-center" *ngIf="!leaveTypesLoading && !leaveTypes.length">
                                   {{'tr_there_are_no_leave_types' | translate}}
@@ -121,6 +121,9 @@
                             </ng-select>
                             <i class="fa fa-caret-down input-icon"></i>
                           </div>
+                          <span class="text-error size-small validator">
+                            {{'tr_required_field' | translate}}
+                          </span>
                         </div>
                       </div>
                       <div class="col-md-3">

--- a/src/app/main/rules/rule-form/rule-form.component.ts
+++ b/src/app/main/rules/rule-form/rule-form.component.ts
@@ -127,7 +127,7 @@ export class RuleFormComponent implements OnInit {
     if (this.rule.tardiness_rules_attributes!.length > 0) {
       this.rule.tardiness_rules_attributes?.forEach(tardinessRule => {
         this.validateStartAndEndTime(tardinessRule);
-        if (tardinessRule.end_time == '' || tardinessRule.start_time == '' || tardinessRule.invalidTime) {
+        if (tardinessRule.end_time == '' || tardinessRule.start_time == '' || tardinessRule.invalidTime || !tardinessRule.leave_type_id) {
           invalidRuleForm = true;
         }
         else invalidRuleForm = false;


### PR DESCRIPTION
## :red_circle: Bug 

### :memo: Problem
- tardiness leave type is allowed to be empty and the system is displayed an error from the backend

### :memo: Solution
- add tardiness leave type validation 


_______________________________________________
### :link: Ticket link https://trianglz.atlassian.net/browse/SKLT-2149
