### PR TITLE
[SKLT-2144][Fingerprint][Attendance sheet] logs should be displayed correctly when the sheet is failed 

### DIFF
--- a/src/app/main/employees-sheet/sheets-list/sheets-list.component.html
+++ b/src/app/main/employees-sheet/sheets-list/sheets-list.component.html
@@ -62,13 +62,10 @@
                     + {{sheet.national_holidays.length - 2}}
                   </div>
                   <div class="options-menu-container">
-                    <div class="national-holidays-container">
                       <div class="single-option"
                       *ngFor="let nationalHoliday of sheet.national_holidays | slice:2:sheet.national_holidays.length">
                       <div class="selected-item-no-border mb-1 bg-secondary"> {{nationalHoliday.day}}</div>
                     </div>
-                    </div>
-                
                   </div>
                 </span>
 

--- a/src/app/main/employees-sheet/sheets-list/sheets-list.component.scss
+++ b/src/app/main/employees-sheet/sheets-list/sheets-list.component.scss
@@ -23,7 +23,7 @@ table{
         }
      }
 }
-.national-holidays-container{
-    max-height: 300px;
+.options-menu-container{
+    max-height: 300px !important;
     overflow-x: auto;
 }


### PR DESCRIPTION

## :red_circle: Bug 

### :memo: Problem
- the logs don't be displayed correctly when the sheet is failed


### :memo: Solution
- add max height to the optional menu

_______________________________________________
### :link: Ticket link https://trianglz.atlassian.net/browse/SKLT-2144
