### PR TITLE
[SKLT-2161][Fingerprint][Time group] employee should be displayed in assigned employee list once the admin checked the employee

### DIFF
--- a/src/app/main/time-groups/edit-time-group/edit-time-group.component.ts
+++ b/src/app/main/time-groups/edit-time-group/edit-time-group.component.ts
@@ -116,8 +116,9 @@ export class EditTimeGroupComponent implements OnInit {
       }
     });
     dialogRef.afterClosed().subscribe(result => {
-      if (result == 'update') {
-        this.getTimeGroup(this.timeGroupId);
+      if (result.message == 'update') {
+        this.timeGroup.employees = result.response.employees
+        this.filterTimeGroupEmployees();
       }
     })
   }

--- a/src/app/main/time-groups/time-schedule/time-schedule.component.ts
+++ b/src/app/main/time-groups/time-schedule/time-schedule.component.ts
@@ -124,7 +124,7 @@ export class TimeScheduleComponent implements OnInit {
     }
     this.subscriptions.push(this.timeGroupService.updateTimeGroupEmployees(this.timeGroupId, updateParams).subscribe(response => {
       this.appNotificationService.push(this.translate.instant('tr_time_schedual_for_employee_updated_ssuccessfuly'), 'success');
-      this.dialogRef.close('update');
+      this.dialogRef.close({message: 'update', response});
     }, error => {
       this.appNotificationService.push(error.error.name, 'error');
     }))


### PR DESCRIPTION
## :information_source: Story/Task 

### :memo: Implementation summary
- Use employees retrieved from update_employees request instead of calling get time groups and employees method again


_______________________________________________
### :link: Ticket link: https://trianglz.atlassian.net/browse/SKLT-2161
