### PR TITLE
[SKLT-2160][Fingerprint][Time group] user should be able to save the time schedule of employee in shift time group

### DIFF
--- a/src/app/main/time-groups/edit-time-group/edit-time-group.component.ts
+++ b/src/app/main/time-groups/edit-time-group/edit-time-group.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { TimeGroup, TimeGroupSchedule } from '@core/models/time-groups-interface.model';
-import { Department, Employee } from '@core/models/employees-interface.model';
+import { Department, Employee, EmployeesAttributes } from '@core/models/employees-interface.model';
 import { PaginationData } from '@core/models/skolera-interfaces.model';
 import { TimeGroupsSerivce } from '@skolera/services/time-groups.services';
 import { AppNotificationService } from '@skolera/services/app-notification.service';
@@ -59,6 +59,7 @@ export class EditTimeGroupComponent implements OnInit {
   @ViewChild('timeGroupForm') announcementForm: NgForm;
   filteredTimeGroupEmployees: Employee[];
   searchTimeOut: any;
+  updatedEmployeesTimeScheduleAttributes: EmployeesAttributes[] = []
 
   constructor(
     private timeGroupService: TimeGroupsSerivce,
@@ -115,10 +116,14 @@ export class EditTimeGroupComponent implements OnInit {
         timeGroupEmployeesIds: this.timeGroup.employees?.map(employee => { return employee.id })
       }
     });
-    dialogRef.afterClosed().subscribe(result => {
-      if (result.message == 'update') {
-        this.timeGroup.employees = result.response.employees
-        this.filterTimeGroupEmployees();
+    dialogRef.afterClosed().subscribe(employeeTimeScheduleParams => {
+      if (employeeTimeScheduleParams) {
+        const existingParamsIndex = this.updatedEmployeesTimeScheduleAttributes.findIndex(employeeAttributes => employeeAttributes.id == employee.id)
+        if(existingParamsIndex < 0){
+          this.updatedEmployeesTimeScheduleAttributes.push(employeeTimeScheduleParams)
+        }else{
+          this.updatedEmployeesTimeScheduleAttributes[existingParamsIndex] = employeeTimeScheduleParams
+        }
       }
     })
   }
@@ -229,7 +234,8 @@ export class EditTimeGroupComponent implements OnInit {
   public updateTimeGroupEmployees() {
     const updateParams = {
       'time_group': {
-        "employee_ids": this.timeGroup.employees?.map(employee => { return employee.id }),
+        "employee_ids": this.timeGroup.employees?.map(employee => employee.id ),
+        "employees_attributes": this.updatedEmployeesTimeScheduleAttributes
       }
     }
     this.subscriptions.push(

--- a/src/app/main/time-groups/time-schedule/time-schedule.component.html
+++ b/src/app/main/time-groups/time-schedule/time-schedule.component.html
@@ -16,7 +16,7 @@
   
           <div class="modal-footer text-right">
             <button class="s-btn btn-primary btn-sm mr-3" type="submit">
-              {{'tr_action.save' | translate}}</button>
+              {{'tr_action.ok' | translate}}</button>
             <button class="s-btn btn-secondary btn-sm" type="reset" (click)="closeModal()"> {{'tr_action.cancel'| translate}}</button>
           </div>
   

--- a/src/app/main/time-groups/time-schedule/time-schedule.component.ts
+++ b/src/app/main/time-groups/time-schedule/time-schedule.component.ts
@@ -94,6 +94,11 @@ export class TimeScheduleComponent implements OnInit {
     let isValidDays: boolean[] = []
 
     this.scheduleDays.forEach(day => {
+      if (day.is_off) {
+        day.clock_in = null;
+        day.clock_out = null;
+      }
+      
       if ((day.clock_in == '' || day.clock_out == '') && !day.is_off) {
         day.invalidTime = true;
         isValidDays.push(true)

--- a/src/app/main/time-groups/time-schedule/time-schedule.component.ts
+++ b/src/app/main/time-groups/time-schedule/time-schedule.component.ts
@@ -106,25 +106,16 @@ export class TimeScheduleComponent implements OnInit {
       return
     }
 
-    const updateParams = {
-      "time_group": {
-        "employee_ids": this.data.timeGroupEmployeesIds,
-        "employees_attributes": {
-          "id": this.employeeId,
-          "time_group_schedule_attributes": {
-            id:  this.data.employeeTimeSchedule? this.data.employeeTimeSchedule.id: null,
-            "schedule_days_attributes": this.scheduleDays
-          }
-        }
+    const employeeTimeScheduleParams = {
+      "id": this.employeeId,
+      "time_group_schedule_attributes": {
+        id:  this.data.employeeTimeSchedule? this.data.employeeTimeSchedule.id: null,
+        "schedule_days_attributes": this.scheduleDays
       }
     }
-    this.subscriptions.push(this.timeGroupService.updateTimeGroupEmployees(this.timeGroupId, updateParams).subscribe(response => {
-      this.appNotificationService.push(this.translate.instant('tr_time_schedual_for_employee_updated_ssuccessfuly'), 'success');
-      this.dialogRef.close({message: 'update', response});
-    }, error => {
-      this.appNotificationService.push(error.error.name, 'error');
-    }))
+    this.dialogRef.close(employeeTimeScheduleParams);
   }
+  
   ngOnDestroy() {
     this.subscriptions.forEach(s => s && s.unsubscribe())
   }

--- a/src/app/main/time-groups/time-schedule/time-schedule.component.ts
+++ b/src/app/main/time-groups/time-schedule/time-schedule.component.ts
@@ -94,10 +94,6 @@ export class TimeScheduleComponent implements OnInit {
     let isValidDays: boolean[] = []
 
     this.scheduleDays.forEach(day => {
-      if (day.is_off) {
-        delete day.clock_in;
-        delete day.clock_out;
-      }
       if ((day.clock_in == '' || day.clock_out == '') && !day.is_off) {
         day.invalidTime = true;
         isValidDays.push(true)


### PR DESCRIPTION
## :red_circle: Bug 

### :memo: Problem
- Clock in and out are not cleared when day is updated to be off in employee time schedule (shifts time group)
- Employee time schedule is updated after setting schedule in dialog.
- If employee was not assigned, then the user assigns him and adds schedule, the employee is added without the user saving.

### :memo: Solution
- Send cleared clock in and out in case of an off day 
- Return employee's time schedule params from time schedule dialog to be saved later when the user saves
- Change "Save" button text in time schedule dialog to "Ok"
- Add updated employee's attributes while updating time group employees 

_______________________________________________
### :link: https://trianglz.atlassian.net/browse/SKLT-2160
