### PR TITLE
[SKLT-2173] Trim search terms in rules, time groups and employees lists

### DIFF
--- a/src/app/main/employees/employees-list/employees-list.component.ts
+++ b/src/app/main/employees/employees-list/employees-list.component.ts
@@ -75,7 +75,7 @@ export class EmployeesListComponent implements OnInit {
   filterEmployees(term: any, searchKey: string) {
     clearTimeout(this.searchTimeout);
     this.searchTimeout = setTimeout(() => {
-      term = (searchKey == 'by_department_id') ? term : term.target.value
+      term = (searchKey == 'by_department_id') ? term : term.target.value.trim()
       this.params[searchKey] = term;
       this.params.page = 1;
       this.getEmployees();

--- a/src/app/main/rules/rules-list/rules-list.component.ts
+++ b/src/app/main/rules/rules-list/rules-list.component.ts
@@ -100,7 +100,7 @@ export class RulesListComponent implements OnInit {
     
   }
   filterRules(term: any){
-    term =  term.target.value
+    term =  term.target.value.trim()
     this.params.page = 1;
     this.params['by_name'] = term;
     this.getRules();

--- a/src/app/main/time-groups/time-groups-list/time-groups-list.component.ts
+++ b/src/app/main/time-groups/time-groups-list/time-groups-list.component.ts
@@ -118,7 +118,7 @@ export class TimeGroupsListComponent implements OnInit {
   filterTimeGroups(event: any, searchKey: string) {
     clearTimeout(this.searchTimeout);
         this.searchTimeout = setTimeout(() => {
-            let term = (searchKey == 'by_type') ? event : event.target.value
+            let term = (searchKey == 'by_type') ? event : event.target.value.trim()
             if (event === null) {
               delete this.params['by_type'];
             }


### PR DESCRIPTION
## :red_circle: Bug 

### :memo: Problem
- Adding whitespace at the end of the search term field returns empty search results 

### :memo: Solution
-  Trim string search terms in rules, time groups and employees' lists

_______________________________________________
### :link: https://trianglz.atlassian.net/browse/SKLT-2173
