### PR TITLE
[SKLT-2177][Fingerprint][Time group] the data related by group types don't display correctly when the user changes the checked box of Group type . 

### DIFF
--- a/src/app/main/time-groups/create-time-group/create-time-group.component.ts
+++ b/src/app/main/time-groups/create-time-group/create-time-group.component.ts
@@ -138,9 +138,6 @@ export class CreateTimeGroupComponent implements OnInit {
       })
 
     }
-    else {
-      delete this.timeGroup.time_group_schedule_attributes
-    }
     if (isValidDays.includes(true)) {
       this.isFormSubmitted = false;
       this.timeGroupService.onInvalidAllDaysTime.next(true)


### PR DESCRIPTION
## :information_source: Story/Task 
## :red_circle: Bug 

### :memo: Problem
- After changing time group type from fixed to shifts,  time group schedule params are removed, so if we change it back to fixed we have errors

### :memo: Solution
- Remove delete time group schedule params before creating time group and the backend will allow creating the schedule for fixed type only.


_______________________________________________
### :link: https://trianglz.atlassian.net/browse/SKLT-2177
