### PR TITLE
[SKLT-2188] [fingerprint][ Attendance sheet ] [Arabic interface]the two sign arrows <> should be switched and don't switch their function in the calendar of start&end date and national holidays dates

### DIFF
--- a/src/assets/style/_global_styles.scss
+++ b/src/assets/style/_global_styles.scss
@@ -1686,6 +1686,9 @@ body,
             margin-#{$start}: auto;
         }
     }
+  .mat-calendar-previous-button, .mat-calendar-next-button {
+        transform: rotate(360deg) !important;
+  }    
 }
 
 @import 'directions/decide';


### PR DESCRIPTION

## :red_circle: Bug 

### :memo: Problem
- wrong direction in the Arabic in two sign arrows <> in the calendar 

### :memo: Solution
- add class to fix direction in the arabic 

_______________________________________________
### :link: Ticket link
https://trianglz.atlassian.net/browse/SKLT-2188